### PR TITLE
fix #15: use "address" keyword for the i2c address

### DIFF
--- a/adafruit_ccs811.py
+++ b/adafruit_ccs811.py
@@ -96,7 +96,7 @@ class CCS811:
     """Temperature offset."""
 
     def __init__(self, i2c_bus, address=0x5A):
-        self.i2c_device = I2CDevice(i2c_bus, addr)
+        self.i2c_device = I2CDevice(i2c_bus, address)
 
         #check that the HW id is correct
         if self.hw_id != _HW_ID_CODE:

--- a/adafruit_ccs811.py
+++ b/adafruit_ccs811.py
@@ -95,7 +95,7 @@ class CCS811:
     temp_offset = 0.0
     """Temperature offset."""
 
-    def __init__(self, i2c_bus, addr=0x5A):
+    def __init__(self, i2c_bus, address=0x5A):
         self.i2c_device = I2CDevice(i2c_bus, addr)
 
         #check that the HW id is correct


### PR DESCRIPTION
To be consistent with all the other drivers.