### PR TITLE
Deprecate temperature

### DIFF
--- a/adafruit_ccs811.py
+++ b/adafruit_ccs811.py
@@ -164,7 +164,11 @@ class CCS811:
 
     @property
     def temperature(self):
-        """Temperature based on optional thermistor in Celsius."""
+        """
+        .. deprecated:: 1.1.5
+           Hardware support removed by vendor
+
+        Temperature based on optional thermistor in Celsius."""
         buf = bytearray(5)
         buf[0] = _NTC
         with self.i2c_device as i2c:

--- a/examples/ccs811_simpletest.py
+++ b/examples/ccs811_simpletest.py
@@ -6,13 +6,11 @@ import adafruit_ccs811
 i2c = busio.I2C(board.SCL, board.SDA)
 ccs811 = adafruit_ccs811.CCS811(i2c)
 
-# Wait for the sensor to be ready and calibrate the thermistor
+# Wait for the sensor to be ready
 while not ccs811.data_ready:
     pass
-temp = ccs811.temperature
-ccs811.temp_offset = temp - 25.0
 
 while True:
-    print("CO2: {} PPM, TVOC: {} PPM, Temp: {} C"
-          .format(ccs811.eco2, ccs811.tvoc, ccs811.temperature))
+    print("CO2: {} PPM, TVOC: {} PPM"
+          .format(ccs811.eco2, ccs811.tvoc)
     time.sleep(0.5)


### PR DESCRIPTION
Hardware support for external thermistor removed by vendor. Remove calls to `temperature` from example and update docstring.