### PR TITLE
Remove more references to temperature property

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,11 +58,11 @@ the CCS811 object
 Reading Sensor
 --------------
 
-To read the gas sensor and temperature simply read the attributes:
+To read the gas sensor simply read the attributes:
 
 .. code:: python
 
-    print("CO2: ", ccs.eco2, " TVOC:", ccs.tvoc, " temp:", ccs.temperature)
+    print("CO2: ", ccs.eco2, " TVOC:", ccs.tvoc)
 
 Contributing
 ============

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     ],
 
     # What does your project relate to?
-    keywords='adafruit air quality voc eco2 temperature breakout hardware micropython circuitpython',
+    keywords='adafruit air quality voc eco2 breakout hardware micropython circuitpython',
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().


### PR DESCRIPTION
Hopefully found them all. All the stuff in `adafruit_ccs811.py` is fine. Removed other mentions from `README.rst` and `setup.py`.
```console
~/Adafruit_CircuitPython_CCS811$ grep -i -r "temperature" *
adafruit_ccs811.py:    """Temperature offset."""
adafruit_ccs811.py:    def temperature(self):
adafruit_ccs811.py:        Temperature based on optional thermistor in Celsius."""
adafruit_ccs811.py:    def set_environmental_data(self, humidity, temperature):
adafruit_ccs811.py:        """Set the temperature and humidity used when computing eCO2 and TVOC values.
adafruit_ccs811.py:        :param float temperature: The current temperature in Celsius."""
adafruit_ccs811.py:        # Temperature is stored as an unsigned 16 bits integer in 1/512 degrees
adafruit_ccs811.py:        # 0x00. As an example 23.5% temperature would be 0x61, 0x00.
adafruit_ccs811.py:        temperature = int((temperature + 25) * 512)
adafruit_ccs811.py:        struct.pack_into(">HH", buf, 1, humidity, temperature)
README.rst:To read the gas sensor and temperature simply read the attributes:
README.rst:    print("CO2: ", ccs.eco2, " TVOC:", ccs.tvoc, " temp:", ccs.temperature)
setup.py:    keywords='adafruit air quality voc eco2 temperature breakout hardware micropython circuitpython',
```