### PR TITLE
remove unused block containing deprecated imp module

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,12 +57,6 @@ intersphinx_mapping = {
     "CircuitPython": ("https://docs.circuitpython.org/en/latest/", None),
 }
 
-# Mock out micropython ourselves.
-# import imp
-# m = imp.new_module("micropython")
-# m.const = lambda x: x
-# sys.modules["micropython"] = m
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
After finding https://github.com/adafruit/Adafruit_CircuitPython_APDS9960/issues/47 I have searched the bundle for instances of `import imp` and found that this library is the only other library in the bundle that has one albeit in a block of commented out code so it's not actually breaking the docs build for this repo. 

This pr removes the commented block.